### PR TITLE
feat: rotate API keys after public rate limits

### DIFF
--- a/src/bitvavo_client/auth/rate_limit.py
+++ b/src/bitvavo_client/auth/rate_limit.py
@@ -34,6 +34,7 @@ class RateLimitManager:
             buffer: Buffer to keep before hitting limit
             strategy: Optional strategy callback when rate limit exceeded
         """
+        self.default_remaining: int = default_remaining
         self.state: dict[int, dict[str, int]] = {-1: {"remaining": default_remaining, "resetAt": 0}}
         self.buffer: int = buffer
 
@@ -99,6 +100,12 @@ class RateLimitManager:
     def handle_limit(self, idx: int, weight: int) -> None:
         """Invoke the configured strategy when rate limit is exceeded."""
         self._strategy(self, idx, weight)
+
+    def reset_key(self, idx: int) -> None:
+        """Reset the remaining budget and reset time for a key index."""
+        self.ensure_key(idx)
+        self.state[idx]["remaining"] = self.default_remaining
+        self.state[idx]["resetAt"] = 0
 
     def get_remaining(self, idx: int) -> int:
         """Get remaining rate limit for key index.

--- a/tests/bitvavo_client/auth/test_rate_limit.py
+++ b/tests/bitvavo_client/auth/test_rate_limit.py
@@ -463,6 +463,16 @@ class TestRateLimitManagerGetters:
         assert 5 in manager.state
         assert reset_at == 0  # New keys always start with resetAt = 0
 
+    def test_reset_key(self) -> None:
+        """Test that reset_key restores default state."""
+        manager = RateLimitManager(default_remaining=1000, buffer=50)
+        manager.ensure_key(0)
+        manager.state[0]["remaining"] = 100
+        manager.state[0]["resetAt"] = 123
+        manager.reset_key(0)
+        assert manager.get_remaining(0) == 1000
+        assert manager.get_reset_at(0) == 0
+
 
 class TestRateLimitManagerIntegration:
     """Integration tests combining multiple rate limit operations."""

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and platform_machine == 'aarch64'",
@@ -48,7 +48,7 @@ wheels = [
 
 [[package]]
 name = "bitvavo-api-upgraded"
-version = "4.1.2"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- start PublicAPI without an API key and add rotation callback for key usage
- track default rate-limit budgets and allow resetting keys
- rotate through API keys and back to keyless access when limits are reached

## Testing
- `uv run -q pre-commit run --files src/bitvavo_client/auth/rate_limit.py src/bitvavo_client/facade.py tests/bitvavo_client/test_facade.py tests/bitvavo_client/auth/test_rate_limit.py`
- `uv run -q pytest tests/bitvavo_client/auth/test_rate_limit.py tests/bitvavo_client/test_facade.py`
- `pytest` *(fails: pyenv missing versions, dependency errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bf5c1d2fd08328ba9f14a25990f6a1