### PR TITLE
feat: initialize rate limit on first call

### DIFF
--- a/tests/bitvavo_client/transport/test_http.py
+++ b/tests/bitvavo_client/transport/test_http.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import httpx
 import pytest
 from returns.result import Success
@@ -11,7 +13,7 @@ from bitvavo_client.core.settings import BitvavoSettings
 from bitvavo_client.transport.http import HTTPClient
 
 
-def test_request_updates_rate_limiter(monkeypatch) -> None:
+def test_request_updates_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     """HTTPClient.request should record weight usage for each call."""
     settings = BitvavoSettings()
     manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
@@ -21,7 +23,7 @@ def test_request_updates_rate_limiter(monkeypatch) -> None:
     # Provide dummy HTTP response
     response = httpx.Response(200, json={})
 
-    def fake_request(method: str, url: str, headers: dict[str, str], body):
+    def fake_request(method: str, url: str, headers: dict[str, str], body: object) -> httpx.Response:
         return response
 
     monkeypatch.setattr(client, "_make_http_request", fake_request)
@@ -30,7 +32,8 @@ def test_request_updates_rate_limiter(monkeypatch) -> None:
     result = client.request("GET", "/test", weight=5)
 
     assert isinstance(result, Success)
-    assert manager.get_remaining(0) == start_remaining - 5
+    # Initial rate limit check consumes 1 weight in addition to the request weight
+    assert manager.get_remaining(0) == start_remaining - 6
 
 
 def test_request_requires_api_key() -> None:
@@ -41,3 +44,102 @@ def test_request_requires_api_key() -> None:
 
     with pytest.raises(RuntimeError, match="API key and secret must be configured"):
         client.request("GET", "/test")
+
+
+def test_initial_rate_limit_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Initial request should fetch rate limit before making the API call."""
+    settings = BitvavoSettings()
+    manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
+    client = HTTPClient(settings, manager)
+    client.configure_key("k", "s", 0)
+
+    responses = [
+        httpx.Response(200, headers={"bitvavo-ratelimit-remaining": "1000"}, json={}),
+        httpx.Response(200, headers={"bitvavo-ratelimit-remaining": "995"}, json={}),
+    ]
+    called_urls: list[str] = []
+
+    def fake_request(method: str, url: str, headers: dict[str, str], body: object) -> httpx.Response:
+        called_urls.append(url)
+        return responses.pop(0)
+
+    monkeypatch.setattr(client, "_make_http_request", fake_request)
+
+    result = client.request("GET", "/test", weight=5)
+
+    assert isinstance(result, Success)
+    assert called_urls == [f"{settings.rest_url}/account", f"{settings.rest_url}/test"]
+    assert manager.get_remaining(0) == 995
+
+
+def test_initial_rate_limit_handles_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client should sleep and retry when initial check returns 429 error 101."""
+    settings = BitvavoSettings()
+    manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
+    client = HTTPClient(settings, manager)
+    client.configure_key("k", "s", 0)
+
+    responses = [
+        httpx.Response(429, json={"error": {"code": 101}}),
+        httpx.Response(200, headers={"bitvavo-ratelimit-remaining": "1000"}, json={}),
+        httpx.Response(200, headers={"bitvavo-ratelimit-remaining": "995"}, json={}),
+    ]
+    called_urls: list[str] = []
+
+    def fake_request(method: str, url: str, headers: dict[str, str], body: object) -> httpx.Response:
+        called_urls.append(url)
+        return responses.pop(0)
+
+    monkeypatch.setattr(client, "_make_http_request", fake_request)
+
+    with patch("time.sleep") as mock_sleep, patch("time.time", return_value=0):
+        result = client.request("GET", "/test", weight=5)
+
+    assert isinstance(result, Success)
+    assert mock_sleep.called
+    assert called_urls == [
+        f"{settings.rest_url}/account",
+        f"{settings.rest_url}/account",
+        f"{settings.rest_url}/test",
+    ]
+    assert manager.get_remaining(0) == 995
+
+
+def test_initial_rate_limit_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client should sleep when initial remaining is below buffer threshold."""
+    settings = BitvavoSettings(rate_limit_buffer=50)
+    manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
+    client = HTTPClient(settings, manager)
+    client.configure_key("k", "s", 0)
+
+    responses = [
+        httpx.Response(
+            200,
+            headers={
+                "bitvavo-ratelimit-remaining": "40",
+                "bitvavo-ratelimit-resetat": "60000",
+            },
+            json={},
+        ),
+        httpx.Response(200, headers={"bitvavo-ratelimit-remaining": "1000"}, json={}),
+        httpx.Response(200, headers={"bitvavo-ratelimit-remaining": "995"}, json={}),
+    ]
+    called_urls: list[str] = []
+
+    def fake_request(method: str, url: str, headers: dict[str, str], body: object) -> httpx.Response:
+        called_urls.append(url)
+        return responses.pop(0)
+
+    monkeypatch.setattr(client, "_make_http_request", fake_request)
+
+    with patch("time.sleep") as mock_sleep, patch("time.time", return_value=0):
+        result = client.request("GET", "/test", weight=5)
+
+    assert isinstance(result, Success)
+    assert mock_sleep.called
+    assert called_urls == [
+        f"{settings.rest_url}/account",
+        f"{settings.rest_url}/account",
+        f"{settings.rest_url}/test",
+    ]
+    assert manager.get_remaining(0) == 995


### PR DESCRIPTION
## Summary
- acquire initial rate limit on first authenticated request
- sleep and retry when initial check hits rate limit
- pause if starting budget is below buffer

## Testing
- `uvx pre-commit run --files src/bitvavo_client/transport/http.py tests/bitvavo_client/transport/test_http.py tests/bitvavo_client/transport/__init__.py`
- `uv run pytest tests/bitvavo_client/transport/test_http.py`

------
https://chatgpt.com/codex/tasks/task_e_68c09baba23c83289a83adb66dc0f564