### PR TITLE
feat(http): add automatic key rotation

### DIFF
--- a/src/bitvavo_client/facade.py
+++ b/src/bitvavo_client/facade.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-import time
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from bitvavo_client.auth.rate_limit import RateLimitManager
 from bitvavo_client.core.settings import BitvavoSettings
@@ -13,8 +12,6 @@ from bitvavo_client.transport.http import HTTPClient
 
 if TYPE_CHECKING:  # pragma: no cover
     from bitvavo_client.core.model_preferences import ModelPreference
-
-T = TypeVar("T")
 
 
 class BitvavoClient:
@@ -47,53 +44,13 @@ class BitvavoClient:
         self.http = HTTPClient(self.settings, self.rate_limiter)
 
         # Initialize API endpoint handlers with preferred model settings
-        self.public = PublicAPI(self.http, preferred_model=preferred_model, default_schema=default_schema)
-        self.private = PrivateAPI(self.http, preferred_model=preferred_model, default_schema=default_schema)
-
-        # Configure API keys if available
-        self._api_keys: list[tuple[str, str]] = []
-        self._current_key: int = -1
-        self._configure_api_keys()
-
-    def _configure_api_keys(self) -> None:
-        """Configure API keys for authentication."""
-        # Collect keys from settings
-        if self.settings.api_key and self.settings.api_secret:
-            self._api_keys.append((self.settings.api_key, self.settings.api_secret))
-        if self.settings.api_keys:
-            self._api_keys.extend((item["key"], item["secret"]) for item in self.settings.api_keys)
-
-        if not self._api_keys:
-            return
-
-        for idx, (_key, _secret) in enumerate(self._api_keys):
-            self.rate_limiter.ensure_key(idx)
-
-        self.http.set_key_rotation_callback(self.rotate_key)
-        key, secret = self._api_keys[0]
-        self.http.configure_key(key, secret, 0)
-        self._current_key = 0
-
-    def rotate_key(self) -> bool:
-        """Rotate to the next configured API key if available."""
-        if not self._api_keys:
-            return False
-
-        next_idx = (self._current_key + 1) % len(self._api_keys)
-        now = int(time.time() * 1000)
-        if now < self.rate_limiter.get_reset_at(next_idx):
-            self.rate_limiter.sleep_until_reset(next_idx)
-        self.rate_limiter.reset_key(next_idx)
-        self._current_key = next_idx
-        key, secret = self._api_keys[next_idx]
-        self.http.configure_key(key, secret, next_idx)
-        return True
-
-    def select_key(self, index: int) -> None:
-        """Select a specific API key by index."""
-        if not (0 <= index < len(self._api_keys)):
-            msg = "API key index out of range"
-            raise IndexError(msg)
-        self._current_key = index
-        key, secret = self._api_keys[index]
-        self.http.configure_key(key, secret, index)
+        self.public = PublicAPI(
+            self.http,
+            preferred_model=preferred_model,
+            default_schema=default_schema,
+        )
+        self.private = PrivateAPI(
+            self.http,
+            preferred_model=preferred_model,
+            default_schema=default_schema,
+        )

--- a/tests/bitvavo_client/endpoints/test_private.py
+++ b/tests/bitvavo_client/endpoints/test_private.py
@@ -128,10 +128,6 @@ class TestPrivateAPI_RAW(AbstractPrivateAPITests):  # noqa: N801
         )
         http = HTTPClient(settings, rate_limiter)
 
-        # Configure API credentials if available
-        if settings.api_key and settings.api_secret:
-            http.configure_key(settings.api_key, settings.api_secret, 0)
-
         return PrivateAPI(http, preferred_model=ModelPreference.RAW)
 
     def _validate_order_data(self, order_dict: dict) -> None:
@@ -1579,9 +1575,6 @@ class TestPrivateAPI_PYDANTIC(AbstractPrivateAPITests):  # noqa: N801
         )
         http = HTTPClient(settings, rate_limiter)
 
-        if settings.api_key and settings.api_secret:
-            http.configure_key(settings.api_key, settings.api_secret, 0)
-
         return PrivateAPI(http, preferred_model=ModelPreference.PYDANTIC)
 
     def test_account(self, private_api: PrivateAPI, expected_caps: set[str]) -> None:
@@ -2024,9 +2017,6 @@ class TestPrivateAPI_DATAFRAME(AbstractPrivateAPITests):  # noqa: N801
             settings.rate_limit_buffer,
         )
         http = HTTPClient(settings, rate_limiter)
-
-        if settings.api_key and settings.api_secret:
-            http.configure_key(settings.api_key, settings.api_secret, 0)
 
         return PrivateAPI(http, preferred_model=ModelPreference.POLARS)
 

--- a/tests/bitvavo_client/transport/test_http.py
+++ b/tests/bitvavo_client/transport/test_http.py
@@ -2,23 +2,25 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import httpx
-import pytest
 from returns.result import Success
 
 from bitvavo_client.auth.rate_limit import RateLimitManager
 from bitvavo_client.core.settings import BitvavoSettings
 from bitvavo_client.transport.http import HTTPClient
 
+if TYPE_CHECKING:  # pragma: no cover
+    import pytest
+
 
 def test_request_updates_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     """HTTPClient.request should record weight usage for each call."""
-    settings = BitvavoSettings()
+    settings = BitvavoSettings(api_keys=[{"key": "k", "secret": "s"}])
     manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
     client = HTTPClient(settings, manager)
-    client.configure_key("k", "s", 0)
 
     # Provide dummy HTTP response
     response = httpx.Response(200, json={})
@@ -36,22 +38,27 @@ def test_request_updates_rate_limiter(monkeypatch: pytest.MonkeyPatch) -> None:
     assert manager.get_remaining(0) == start_remaining - 6
 
 
-def test_request_requires_api_key() -> None:
-    """HTTPClient.request should raise if no API key configured."""
+def test_request_without_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTPClient.request should work without API key for public endpoints."""
     settings = BitvavoSettings()
     manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
     client = HTTPClient(settings, manager)
 
-    with pytest.raises(RuntimeError, match="API key and secret must be configured"):
-        client.request("GET", "/test")
+    response = httpx.Response(200, json={})
+    monkeypatch.setattr(client, "_make_http_request", lambda m, u, h, b: response)
+
+    start_remaining = manager.get_remaining(-1)
+    result = client.request("GET", "/test")
+
+    assert isinstance(result, Success)
+    assert manager.get_remaining(-1) == start_remaining - 1
 
 
 def test_initial_rate_limit_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Initial request should fetch rate limit before making the API call."""
-    settings = BitvavoSettings()
+    settings = BitvavoSettings(api_keys=[{"key": "k", "secret": "s"}])
     manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
     client = HTTPClient(settings, manager)
-    client.configure_key("k", "s", 0)
 
     responses = [
         httpx.Response(200, headers={"bitvavo-ratelimit-remaining": "1000"}, json={}),
@@ -74,10 +81,9 @@ def test_initial_rate_limit_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_initial_rate_limit_handles_429(monkeypatch: pytest.MonkeyPatch) -> None:
     """Client should sleep and retry when initial check returns 429 error 101."""
-    settings = BitvavoSettings()
+    settings = BitvavoSettings(api_keys=[{"key": "k", "secret": "s"}])
     manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
     client = HTTPClient(settings, manager)
-    client.configure_key("k", "s", 0)
 
     responses = [
         httpx.Response(429, json={"error": {"code": 101}}),
@@ -107,10 +113,9 @@ def test_initial_rate_limit_handles_429(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_initial_rate_limit_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
     """Client should sleep when initial remaining is below buffer threshold."""
-    settings = BitvavoSettings(rate_limit_buffer=50)
+    settings = BitvavoSettings(api_keys=[{"key": "k", "secret": "s"}], rate_limit_buffer=50)
     manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
     client = HTTPClient(settings, manager)
-    client.configure_key("k", "s", 0)
 
     responses = [
         httpx.Response(
@@ -143,3 +148,31 @@ def test_initial_rate_limit_below_threshold(monkeypatch: pytest.MonkeyPatch) -> 
         f"{settings.rest_url}/test",
     ]
     assert manager.get_remaining(0) == 995
+
+
+def test_request_rotates_keys_when_budget_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client should rotate to next API key when current key has no budget."""
+    settings = BitvavoSettings(
+        api_keys=[{"key": "k1", "secret": "s1"}, {"key": "k2", "secret": "s2"}],
+    )
+    manager = RateLimitManager(settings.default_rate_limit, settings.rate_limit_buffer)
+    client = HTTPClient(settings, manager)
+
+    # Skip initial rate limit call
+    monkeypatch.setattr(client, "_ensure_rate_limit_initialized", lambda: None)
+
+    def has_budget(idx: int, weight: int) -> bool:
+        return idx == 1
+
+    monkeypatch.setattr(manager, "has_budget", has_budget)
+    monkeypatch.setattr(manager, "get_reset_at", lambda idx: 0)
+    monkeypatch.setattr(manager, "sleep_until_reset", lambda idx: None)
+    monkeypatch.setattr(manager, "reset_key", lambda idx: None)
+
+    response = httpx.Response(200, json={})
+    monkeypatch.setattr(client, "_make_http_request", lambda m, u, h, b: response)
+
+    result = client.request("GET", "/test")
+
+    assert isinstance(result, Success)
+    assert client.key_index == 1


### PR DESCRIPTION
## Summary
- load API keys from settings in HTTPClient and rotate through them when needed
- allow keyless requests and simplify BitvavoClient facade
- adjust tests for new key handling

## Testing
- `pre-commit run --files src/bitvavo_client/transport/http.py src/bitvavo_client/facade.py tests/bitvavo_client/transport/test_http.py tests/bitvavo_client/test_facade.py tests/bitvavo_client/endpoints/test_private.py`
- `pytest tests/bitvavo_client/transport/test_http.py tests/bitvavo_client/test_facade.py tests/bitvavo_client/endpoints/test_private.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0a4910fcc8328b4e815342d9805b3